### PR TITLE
Retired katas

### DIFF
--- a/src/data/codewarsChallenges.ts
+++ b/src/data/codewarsChallenges.ts
@@ -253,7 +253,7 @@ export const codeWarsChallenges: CodeWarsChallenge[] = [
   },
   {
     title: "Implement Array.prototype.filter()",
-    link: ""
+    link: "https://www.codewars.com/kata/56dd9b84fe5754786f0014f7"
   },
   {
     title: "Sum Times Tables",
@@ -317,11 +317,11 @@ export const codeWarsChallenges: CodeWarsChallenge[] = [
   },
   {
     title: "Maximum Gap (Array Series #4)",
-    link: "Array Series #4"
+    link: "https://www.codewars.com/kata/5a7893ef0025e9eb50000013"
   },
   {
     title: "Tidy Number (Special Numbers Series #9)",
-    link: "Special Numbers Series #9"
+    link: "https://www.codewars.com/kata/5a87449ab1710171300000fd"
   },
   {
     title: "Row Weights",
@@ -341,7 +341,7 @@ export const codeWarsChallenges: CodeWarsChallenge[] = [
   },
   {
     title: "Product Array (Array Series #5)",
-    link: "Array Series #5"
+    link: "https://www.codewars.com/kata/5a905c2157c562994900009d"
   },
   {
     title: "Dominant array elements",
@@ -429,7 +429,7 @@ export const codeWarsChallenges: CodeWarsChallenge[] = [
   },
   {
     title: "Bingo ( Or Not )",
-    link: " Or Not "
+    link: "https://www.codewars.com/kata/5a1ee4dfffe75f0fcb000145"
   },
   {
     title: "Sum of numbers from 0 to N",

--- a/src/data/codewarsChallenges.ts
+++ b/src/data/codewarsChallenges.ts
@@ -164,10 +164,6 @@ export const codeWarsChallenges: CodeWarsChallenge[] = [
     link: "https://www.codewars.com/kata/55f7eb009e6614447b000099"
   },
   {
-    title: "Thinkful - List Drills: Longest word",
-    link: "https://www.codewars.com/kata/58670300f04e7449290000e5"
-  },
-  {
     title: "max diff - easy",
     link: "https://www.codewars.com/kata/588a3c3ef0fbc9c8e1000095"
   },
@@ -198,10 +194,6 @@ export const codeWarsChallenges: CodeWarsChallenge[] = [
   {
     title: "Duck Duck Goose",
     link: "https://www.codewars.com/kata/582e0e592029ea10530009ce"
-  },
-  {
-    title: "How many animals are there?",
-    link: "https://www.codewars.com/kata/593406b8f3d071d83c00005d"
   },
   {
     title: "8kyu interpreters: HQ9+",
@@ -252,10 +244,6 @@ export const codeWarsChallenges: CodeWarsChallenge[] = [
     link: "https://www.codewars.com/kata/55a144eff5124e546400005a"
   },
   {
-    title: "Factorial Factory",
-    link: "https://www.codewars.com/kata/528e95af53dcdb40b5000171/javascript"
-  },
-  {
     title: "Closest to Zero",
     link: "https://www.codewars.com/kata/59887207635904314100007b"
   },
@@ -294,10 +282,6 @@ export const codeWarsChallenges: CodeWarsChallenge[] = [
   {
     title: "Possiblities Array",
     link: "https://www.codewars.com/kata/59b710ed70a3b7dd8f000027"
-  },
-  {
-    title: "Man in the west",
-    link: "https://www.codewars.com/kata/59bd5dc270a3b7350c00008b"
   },
   {
     title: "Matrix creation",
@@ -508,16 +492,8 @@ export const codeWarsChallenges: CodeWarsChallenge[] = [
     link: "https://www.codewars.com/kata/5d376cdc9bcee7001fcb84c0"
   },
   {
-    title: "Valid Parentheses",
-    link: "https://www.codewars.com/kata/52774a314c2333f0a7000688"
-  },
-  {
     title: "Finding length of the sequence",
     link: "https://www.codewars.com/kata/5566b0dd450172dfc4000005"
-  },
-  {
-    title: "Count letters in string",
-    link: "https://www.codewars.com/kata/5808ff71c7cfa1c6aa00006d"
   },
   {
     title: "The First Non Repeated Character In A String",


### PR DESCRIPTION
Going through the links to the CodeWars katas I found two things:
- some katas have been retired by the platform. Looks like you can still do them but I doubt you can earn rank/honour points for it, so gamification element is lost
- some links had the wrong text. This is because I wrote a script to go through my original markdown file containing this list of katas and convert them to JS object syntax. Turns out my regex skills failed me in some cases!

Completed work:
- removed katas that I found to have been retired by the CodeWars platform
- added missing urls in existing katas