### PR TITLE
Add information about how to contribute to the project

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,7 +1,23 @@
-# Contributors 
+# Maintainers
 
 - [Nnamdi Michael Okpala](https://www.github.com/okpalan)
 - [Alexander Brown](https://github.com/webtechalex)
 - [Carlos Ferreira](https://github.com/cajogos)
 - [Vu Dao](https://github.com/v24dao)
 - [Rob Chu](https://github.com/RobChooses)
+
+# How to Contribute
+
+To get started making a change to this project: fork this repo to your own GitHub account; clone the fork; make your changes on your clone; commit and push your changes to your fork.
+Once you have your changes on your fork on GitHub, make a pull request to the main branch in the freeCodeCampLondon/fcc-website repo.
+You can help maintainers to get your code merged more quickly by filling out the description field in the PR, giving a clear description of changes and their rationale. If you have made any design changes or additions, adding appropriate screenshots may also help get things merged quickly.
+
+# Advice for new developers
+
+When we start learning to code, most often we practise on our own, and we don't use version control. Using version control can be a difficult challenge in the first days of our first job.
+We hope that members of the freeCodeCamp London community will benefit from the experience of contributing to this project by becoming familiar with how teams collaborate on software development in a work environment.
+
+### I'm new to all this. How do I get started?
+If you are a new developer, and you haven't used version control tools such as Git and GitHub before, the experience can be confusing at first.
+A good place to start is to check out [freeCodeCamp's own article on Git and GitHub](https://www.freecodecamp.org/news/introduction-to-git-and-github/). The article explains key concepts and contains links to other resources so that you can get more information or alternative explanations as needed.
+Also feel free to drop into our discord and ask us for advice!

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,11 +1,3 @@
-# Maintainers
-
-- [Nnamdi Michael Okpala](https://www.github.com/okpalan)
-- [Alexander Brown](https://github.com/webtechalex)
-- [Carlos Ferreira](https://github.com/cajogos)
-- [Vu Dao](https://github.com/v24dao)
-- [Rob Chu](https://github.com/RobChooses)
-
 # How to Contribute
 
 To get started making a change to this project: fork this repo to your own GitHub account; clone the fork; make your changes on your clone; commit and push your changes to your fork.
@@ -18,6 +10,15 @@ When we start learning to code, most often we practise on our own, and we don't 
 We hope that members of the freeCodeCamp London community will benefit from the experience of contributing to this project by becoming familiar with how teams collaborate on software development in a work environment.
 
 ### I'm new to all this. How do I get started?
+
 If you are a new developer, and you haven't used version control tools such as Git and GitHub before, the experience can be confusing at first.
 A good place to start is to check out [freeCodeCamp's own article on Git and GitHub](https://www.freecodecamp.org/news/introduction-to-git-and-github/). The article explains key concepts and contains links to other resources so that you can get more information or alternative explanations as needed.
 Also feel free to drop into our discord and ask us for advice!
+
+# Maintainers
+
+- [Nnamdi Michael Okpala](https://www.github.com/okpalan)
+- [Alexander Brown](https://github.com/webtechalex)
+- [Carlos Ferreira](https://github.com/cajogos)
+- [Vu Dao](https://github.com/v24dao)
+- [Rob Chu](https://github.com/RobChooses)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,3 +1,11 @@
+# Contributors
+
+- [Nnamdi Michael Okpala](https://www.github.com/okpalan)
+- [Alexander Brown](https://github.com/webtechalex)
+- [Carlos Ferreira](https://github.com/cajogos)
+- [Vu Dao](https://github.com/v24dao)
+- [Rob Chu](https://github.com/RobChooses)
+
 # How to Contribute
 
 To get started making a change to this project: fork this repo to your own GitHub account; clone the fork; make your changes on your clone; commit and push your changes to your fork.
@@ -14,11 +22,3 @@ We hope that members of the freeCodeCamp London community will benefit from the 
 If you are a new developer, and you haven't used version control tools such as Git and GitHub before, the experience can be confusing at first.
 A good place to start is to check out [freeCodeCamp's own article on Git and GitHub](https://www.freecodecamp.org/news/introduction-to-git-and-github/). The article explains key concepts and contains links to other resources so that you can get more information or alternative explanations as needed.
 Also feel free to drop into our discord and ask us for advice!
-
-# Maintainers
-
-- [Nnamdi Michael Okpala](https://www.github.com/okpalan)
-- [Alexander Brown](https://github.com/webtechalex)
-- [Carlos Ferreira](https://github.com/cajogos)
-- [Vu Dao](https://github.com/v24dao)
-- [Rob Chu](https://github.com/RobChooses)

--- a/README.md
+++ b/README.md
@@ -2,7 +2,9 @@
 
 Hello campers!
 
-This is the [official website](https://freecodecamp.london/) for the freeCodeCamp London group. 
+This is the [official website](https://freecodecamp.london/) for the freeCodeCamp London group.
+
+For details on how to get started contributing to this project, please see our advice and instructions [here](CONTRIBUTING.md)
 
 Our group typically meets up once per month in locations around Central London. All abilities are welcome, from absolute beginner to professional!
 


### PR DESCRIPTION
Completed:
- added information and advice about how to contribute to the project that is appropriate to those new to git and GitHub, and to developing software as part of a team
- added a link to the CONTRIBUTING file on the README
- ~also changed the "Contributors" heading in CONTRIBUTING.md to "Maintainers".~
- ~moved the "Maintainers" content to the bottom of the page (if it gets really long maybe it obscures the more useful info)~

I realise I may have confused things by both moving _and_ renaming the "Contributors" header. I don't know whether we want to have a list of all the contributors on this page, or just the maintainers. If it's just the maintainers, it could stay at the top, as it's unlikely to become very long. If we want to list all contributors, maybe it goes at the bottom of the page or on a dedicated page.
[UPDATE]: reverted the change about the contributors header. It's not a problem for now and we can discuss away from GitHub