### PR TITLE
Lint action config

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -1,0 +1,19 @@
+name: pr-checks
+on:
+  pull_request:
+    types: [opened, reopened, synchronize]
+jobs:
+  analyse:
+    name: Check code formatting
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+          node-version: '20'
+      - name: install
+        run: npm install
+      - name: ESLint
+        run: npm run lint
+      - name: Prettier
+        run: npm run format

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "build": "astro check && astro build",
     "preview": "astro preview",
     "astro": "astro",
-    "lint": "prettier --write  \"**/*.{js,jsx,ts,tsx,md,mdx,astro}\" && eslint --fix \"src/**/*.{js,ts,jsx,tsx,astro}\""
+    "lint": "eslint \"src/**/*.{js,ts,jsx,tsx,astro}\"",
+    "format": "prettier  \"**/*.{js,jsx,ts,tsx,md,mdx,astro}\""
   },
   "dependencies": {
     "@astrojs/check": "^0.9.4",


### PR DESCRIPTION
Adding configuration file for GitHub action to run linting and fomatting against PRs and ensure contributors adhere to code style in the interest of maintainability.

Previously, the linting and formatting package scripts were one script. I separated them so that they can be run (and reported on) individually by the GH action.