### PR TITLE
Updated the description in Layout.astro meta tag

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,6 +6,7 @@
 - [Vu Dao](https://github.com/v24dao)
 - [Rob Chu](https://github.com/RobChooses)
 - [Dempsey Palacio Tascon](https://github.com/deej-tsn)
+- [Helen Sou](https://github.com/HSSH686)
 
 # How to Contribute
 

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -10,7 +10,7 @@ const { title } = Astro.props;
 <html lang="en">
     <head>
         <meta charset="UTF-8" />
-        <meta name="description" content="Astro description" />
+        <meta name="description" content="freeCodeCamp London project website" />
         <meta name="viewport" content="width=device-width" />
         <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
         <meta name="generator" content={Astro.generator} />


### PR DESCRIPTION
Sorry, I seem to have accidently closed my pull request (request #29) from last week before the changes were approved and reflected in the original fcc repository! As such, my changes were not incorporated into the original repository. 

I synced my copy of the repository to reflect the latest changes to the original repository before making the below two changes again:
1. Changed the description in Layout.astro meta tag from "Astro description" to "freeCodeCamp London project website". 
2. Added my name to CONTRIBUTING.md.

The change in point (1) is in response to the task here: https://github.com/orgs/freeCodeCampLondon/projects/1/views/1?pane=issue&itemId=89720955&issue=freeCodeCampLondon%7Cfcc-website%7C25